### PR TITLE
tests: upgrade of pytest to >=2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ python:
   - "pypy"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements.txt
+install: pip install check-manifest -r requirements.txt
 
 # command to run tests, e.g. python setup.py test
 script: python setup.py test
+  - "check-manifest --ignore .travis-\\*-requirements.txt"


### PR DESCRIPTION
* FIX Upgrades pytest minimum version to 2.8.0.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>