### PR TITLE
CMS logo

### DIFF
--- a/invenio_previewer_ispy/bundles.py
+++ b/invenio_previewer_ispy/bundles.py
@@ -74,7 +74,7 @@ js = Bundle(
     filters="requirejs",
     weight=51,
     bower={
-    "ispy-webgl": "0.9.4-invenio.15"
+    "ispy-webgl": "0.9.4-invenio.17"
     }
 )
 

--- a/invenio_previewer_ispy/templates/previewer/ispy_base.html
+++ b/invenio_previewer_ispy/templates/previewer/ispy_base.html
@@ -120,7 +120,7 @@
 <div id="event-info" class="black">
 <table>
 	<tr>
-		<td id="cms-logo"></td>
+		<td id="cms-logo"><img src="{{ url_for('static', filename='vendors/ispy-webgl/graphics/cms-color-medium.png')}}"/></td>
 		<td id="event-text"></td>
 	</tr>
 </table>


### PR DESCRIPTION
* Show the CMS logo by default when loaded.

* Use v17 of display in bundles.

* This should fix #874 in opendata.cern.ch.