### PR TITLE
increment ispy-webgl in bundles

### DIFF
--- a/invenio_previewer_ispy/bundles.py
+++ b/invenio_previewer_ispy/bundles.py
@@ -74,7 +74,7 @@ js = Bundle(
     filters="requirejs",
     weight=51,
     bower={
-    "ispy-webgl": "0.9.4-invenio.17"
+    "ispy-webgl": "0.9.4-invenio.18"
     }
 )
 


### PR DESCRIPTION
The version of ispy-webgl specified in the bundles creates a directory-like structure in the file loader so that files from multiple years (which may have the same name) can be used.